### PR TITLE
MARSSkfss

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: MARSS
 Type: Package
 Title: Multivariate Autoregressive State-Space Modeling
-Version: 3.11.2
-Date: 2020-09-12
+Version: 3.11.3
+Date: 2020-09-13
 Depends: R (>= 3.5.0)
 Imports: 
     graphics, grDevices, KFAS (>= 1.0.1), mvtnorm, nlme, stats, utils

--- a/R/MARSS.R
+++ b/R/MARSS.R
@@ -227,7 +227,7 @@ MARSS <- function(y,
         if (MLEobj$control$trace > 0) {
           if (fun.kf == "MARSSkfas") {
             kfss <- try(MARSSkfss(MLEobj, smoother = FALSE), silent = TRUE)
-            if (inherits(kfss, "try-error" || !kfss$ok)) {
+            if (inherits(kfss, "try-error") || !kfss$ok) {
               msg <- "Not available. MARSSkfss() returned error."
               kfss <- list(Innov = msg, Sigma = msg, xtt = msg, Vtt = msg, J = msg, Kt = msg)
             }

--- a/R/MARSS.R
+++ b/R/MARSS.R
@@ -125,29 +125,29 @@ MARSS <- function(y,
       return(MLEobj)
     }
 
+    # Check that Kalman filter/smoother will run
     if (MLEobj$control$trace != -1) {
       MLEobj.test <- MLEobj
       MLEobj.test$par <- MLEobj$start
-      # Do this test with MARSSkfss since it has internal tests for problems
-      kftest <- try(MARSSkfss(MLEobj.test), silent = TRUE)
+      kftest <- try(MARSSkf(MLEobj.test), silent = TRUE)
       if (inherits(kftest, "try-error")) {
-        cat("Error: Stopped in MARSS() before fitting because MARSSkfss stopped.  Something in the model structure prevents the kfss Kalman filter running.\n Try using control$trace=-1 to turn off error-checking (and MARSSkfss calls) or use fit=FALSE and check the model you are trying to fit.\n")
+        cat("Error: Stopped in MARSS() before fitting because", fun.kf,  "stopped.  Something in the model structure prevents the Kalman filter or smoother running.\n Try setting fun.kf to use a different KF function (MARSSkfss or MARSSkfas) or use fit=FALSE and check the model you are trying to fit. You can also try trace=1 to get more progress output.\n")
         MLEobj$convergence <- 2
         return(MLEobj.test)
       }
       if (!kftest$ok) {
         cat(kftest$msg)
-        cat(paste("Error: Stopped in MARSS() before fitting because MARSSkfss stopped.  Something in the model structure prevents the kfss Kalman filter running.\n Try using control$trace=-1 to turn off error-checking (and MARSSkfss calls) or use fit=FALSE and check the model you are trying to fit.\n", kftest$errors, "\n", sep = ""))
+        cat(paste("Error: Stopped in MARSS() before fitting because", fun.kf, "stopped.  Something in the model structure prevents the Kalman filter or smoother running.\n Try setting fun.kf to use a different KF function (MARSSkfss or MARSSkfas) or use fit=FALSE and check the model you are trying to fit. You can also try trace=1 to get more progress output.\n", kftest$errors, "\n", sep = ""))
         MLEobj$convergence <- 2
         return(MLEobj.test)
       }
       MLEobj.test$kf <- kftest
     }
     # Ey is needed for method=kem
-    if (MLEobj$control$trace != -1 & MLEobj$method == "kem") {
+    if (MLEobj$control$trace != -1 && MLEobj$method  %in% kem.methods) {
       Eytest <- try(MARSShatyt(MLEobj.test), silent = TRUE)
       if (inherits(Eytest, "try-error")) {
-        cat("Error: Stopped in MARSS() before fitting because MARSShatyt stopped.  Something is wrong with the model structure that prevents MARSShatyt running.\n\n")
+        cat("Error: Stopped in MARSS() before fitting because MARSShatyt() stopped.  Something is wrong with the model structure that prevents MARSShatyt() running.\n\n")
         MLEobj.test$convergence <- 2
         MLEobj.test$Ey <- Eytest
         return(MLEobj.test)
@@ -159,7 +159,6 @@ MARSS <- function(y,
         MLEobj.test$Ey <- Eytest
         return(MLEobj.test)
       }
-      # MLEobj$Ey=Eytest
     }
 
     if (!fit) MLEobj$convergence <- 3
@@ -185,10 +184,11 @@ MARSS <- function(y,
         MLEobj <- MARSSaic(MLEobj)
         MLEobj$coef <- coef(MLEobj, type = "vector")
       }
+      
       ## Add states.se and ytT.se if no errors.  Return kf and Ey if trace>0
-      if ((MLEobj$convergence %in% c(0, 1, 3)) || (MLEobj$convergence %in% c(10, 11) && method %in% kem.methods)) {
+      if ( MLEobj$convergence %in% c(0, 1, 3) ||( MLEobj$convergence %in% c(10, 11)  && MLEobj$method %in% kem.methods) ) {
         if (silent == 2) cat("Adding states and states.se.\n")
-        kf <- MARSSkf(MLEobj) # use function requested by user
+        kf <- MARSSkf(MLEobj) # use function requested by user; default smoother=TRUE
         MLEobj$states <- kf$xtT
         MLEobj$logLik <- kf$logLik
         if (!is.null(kf[["VtT"]])) {
@@ -222,23 +222,32 @@ MARSS <- function(y,
           ytT.se <- NULL
         }
         MLEobj$ytT.se <- ytT.se
-        if (MLEobj$control$trace > 0) { # then return kf and Ey
-          if (fun.kf == "MARSSkfas") kfss <- MARSSkfss(MLEobj) else kfss <- kf
+        
+        # Return kf and Ey, if trace = 1
+        if (MLEobj$control$trace > 0) { 
+          if (fun.kf == "MARSSkfas") kfss <- MARSSkfss(MLEobj, smoother=FALSE) else kfss <- kf
           MLEobj$kf <- kf # from above will use function requested by user
-          # except these are only returned by MARSSkfss
+          MLEobj$Ey <- Ey # from above
+          # these are only returned by MARSSkfss
           MLEobj$Innov <- kfss$Innov
           MLEobj$Sigma <- kfss$Sigma
           MLEobj$Vtt <- kfss$Vtt
           MLEobj$xtt <- kfss$xtt
           MLEobj$J <- kfss$J
-          MLEobj$J0 <- kfss$J0
           MLEobj$Kt <- kfss$Kt
-          MLEobj$Ey <- MARSShatyt(MLEobj)
+          if (fun.kf == "MARSSkfss"){
+            # From kfss smoother so won't necessarily be available if fun.kf=MARSSkfas
+            MLEobj$J0 <- kfss$J0
+          } else {
+            J0 <- try(MARSSkfss(MLEobj), silent = TRUE)
+            if (!inherits(J0, "try-error") && J0$ok) MLEobj$J0 <- J0$J0 else MLEobj$J0 <- "Not available. MARSSkfss() smoother returned error."
+          }
         }
         # apply X and Y names various X and Y related elements
         MLEobj <- MARSSapplynames(MLEobj)
       }
-    } # fit the model
+    } 
+    # END fit the model #################
 
     if ((!silent || silent == 2) & MLEobj$convergence %in% c(0, 1, 3, 10, 11, 12)) {
       print(MLEobj)

--- a/R/MARSSkf.r
+++ b/R/MARSSkf.r
@@ -2,7 +2,7 @@
 #   MARSSkf function
 #   Utility function to choose the Kalman filter and smoother
 #######################################################################################################
-MARSSkf <- function(MLEobj, only.logLik = FALSE, return.lag.one = TRUE, return.kfas.model = FALSE, newdata = NULL) {
+MARSSkf <- function(MLEobj, only.logLik = FALSE, return.lag.one = TRUE, return.kfas.model = FALSE, newdata = NULL, smoother = TRUE) {
   if (is.null(MLEobj$par)) {
     stop("Stopped in MARSSkf(): par element of marssMLE object is required.\n")
   }
@@ -18,7 +18,7 @@ MARSSkf <- function(MLEobj, only.logLik = FALSE, return.lag.one = TRUE, return.k
     MLEobj[["marss"]][["data"]] <- newdata
   }
   if (MLEobj$fun.kf == "MARSSkfss") {
-    return(MARSSkfss(MLEobj))
+    return(MARSSkfss(MLEobj, smoother = smoother))
   }
   if (MLEobj$fun.kf == "MARSSkfas") {
     return(MARSSkfas(MLEobj, only.logLik = only.logLik, return.lag.one = return.lag.one, return.kfas.model = return.kfas.model))

--- a/R/MARSSkfas.r
+++ b/R/MARSSkfas.r
@@ -237,7 +237,7 @@ MARSSkfas <- function(MLEobj, only.logLik = FALSE, return.lag.one = TRUE, return
   
   if (!return.kfas.model) kfas.model <- NULL
   
-  # not using ks.out$v (Innov) and ks.out$F (Sigma) since I think there might be a bug (I misunderstand KFAS) when R is not diagonal.
+  # not using ks.out$v (Innov) and ks.out$F (Sigma) since I think there might be a bug (or I misunderstand KFS output) when R is not diagonal.
   rtn.list <- list(
     xtT = ks.out$alphahat[1:m, , drop = FALSE],
     VtT = VtT,

--- a/man/MARSSkf.Rd
+++ b/man/MARSSkf.Rd
@@ -8,12 +8,13 @@
 }
 \usage{
 MARSSkf(MLEobj, only.logLik=FALSE, return.lag.one=TRUE, return.kfas.model=FALSE, 
-           newdata=NULL)
-MARSSkfss(MLEobj)
+           newdata=NULL, smoother=TRUE)
+MARSSkfss(MLEobj, smoother=TRUE)
 MARSSkfas(MLEobj, only.logLik=FALSE, return.lag.one=TRUE, return.kfas.model=FALSE)
 }
 \arguments{
   \item{ MLEobj }{ A \code{\link{marssMLE}} object with the \code{par} element of estimated parameters, \code{marss} element with the model description (in marss form) and data, and \code{control} element for the fitting algorithm specifications.  \code{control$debugkf} specifies that detailed error reporting will be returned (only used by \code{MARSSkf}).  \code{model$diffuse=TRUE} specifies that a diffuse prior be used (only used by \code{MARSSkfas}). See \link[KFAS]{KFS} documentation. When the diffuse prior is set, V0 should be non-zero since the diffuse prior variance is V0*kappa, where kappa goes to infinity.}
+  \item{ smoother }{ Used by \code{MARSSkfss}.  If set to FALSE, only the Kalman filter is run. xtT, VtT, x0T, Vtt1T, V0T, and J0 will be NULL. }
   \item{ only.logLik }{ Used by \code{MARSSkfas}.  If set, only the log-likelihood is returned using the \link[KFAS]{KFAS} package function \code{\link[KFAS]{logLik.SSModel}}.  This is much faster if only the log-likelihood is needed. }
   \item{ return.lag.one }{ Used by \code{MARSSkfas}.  If set to FALSE, the smoothed lag-one covariance  values are not returned (Vtt1T is set to NULL).  This speeds up \code{MARSSkfas} because to return the smoothed lag-one covariance a stacked MARSS model is used with twice the number of state vectors---thus the state matrices are larger and take more time to work with. }
   \item{ return.kfas.model }{ Used by \code{MARSSkfas}.  If set to TRUE, it returns the MARSS model in \link[KFAS]{KFAS} model form (class \code{\link[KFAS]{SSModel}}).  This is useful if you want to use other KFAS functions or write your own functions to work with \code{\link{optim}} to do optimization.  This can speed things up since there is a bit of code overhead in \code{\link{MARSSoptim}} associated with the \code{\link{marssMODEL}} model specification needed for the constrained EM algorithm (but not strictly needed for \code{\link{optim}}; useful but not required.). }


### PR DESCRIPTION
Make the tests a little less picky regarding passing MARSSkfss(). Models might fit fine with MARSSkfas() so don't require that MARSSkfss() be able to run. Sometimes the inversions fail.